### PR TITLE
Removing socketwrapper parameter

### DIFF
--- a/src/main/java/Main.java
+++ b/src/main/java/Main.java
@@ -5,9 +5,8 @@ public class Main {
     public static void main(String[] args) throws IOException, InterruptedException {
         int port = 5000;
 
-        ServerSocketWrapper socketWrapper = new ServerSocketWrapper();
         Router router = Routes.assignRoutes();
-        Server server = new Server(socketWrapper, router);
+        Server server = new Server(router);
         System.out.println("Server Started");
         server.start(port);
     }

--- a/src/main/java/Server.java
+++ b/src/main/java/Server.java
@@ -1,11 +1,10 @@
 import java.io.IOException;
 
 public class Server {
-    SocketWrapper socketWrapper;
+    SocketWrapper socketWrapper = new ServerSocketWrapper();
     Router router;
 
-    public Server(SocketWrapper socketWrapper, Router router) {
-        this.socketWrapper = socketWrapper;
+    public Server(Router router) {
         this.router = router;
     }
 

--- a/src/main/java/Server.java
+++ b/src/main/java/Server.java
@@ -31,4 +31,8 @@ public class Server {
         }
     }
 
+    public void setSocketWrapper(SocketWrapper socketWrapper) {
+        this.socketWrapper = socketWrapper;
+    }
+
 }

--- a/src/test/java/TestFeatures.java
+++ b/src/test/java/TestFeatures.java
@@ -20,7 +20,8 @@ public class TestFeatures {
 
         Router router = Routes.assignRoutes();
         SocketWrapperSpy socketWrapper = new SocketWrapperSpy(input, output);
-        Server testServer = new Server(socketWrapper, router);
+        Server testServer = new Server(router);
+        testServer.setSocketWrapper(socketWrapper);
 
         testServer.start(port);
 
@@ -43,7 +44,8 @@ public class TestFeatures {
 
         Router router = Routes.assignRoutes();
         SocketWrapperSpy socketWrapper = new SocketWrapperSpy(input, output);
-        Server testServer = new Server(socketWrapper, router);
+        Server testServer = new Server(router);
+        testServer.setSocketWrapper(socketWrapper);
 
         testServer.start(port);
 
@@ -68,7 +70,8 @@ public class TestFeatures {
 
         Router router = Routes.assignRoutes();
         SocketWrapperSpy socketWrapper = new SocketWrapperSpy(input, output);
-        Server testServer = new Server(socketWrapper, router);
+        Server testServer = new Server(router);
+        testServer.setSocketWrapper(socketWrapper);
 
         testServer.start(port);
 
@@ -93,7 +96,8 @@ public class TestFeatures {
 
         Router router = Routes.assignRoutes();
         SocketWrapperSpy socketWrapper = new SocketWrapperSpy(input, output);
-        Server testServer = new Server(socketWrapper, router);
+        Server testServer = new Server(router);
+        testServer.setSocketWrapper(socketWrapper);
 
         testServer.start(port);
 
@@ -116,7 +120,8 @@ public class TestFeatures {
 
         Router router = Routes.assignRoutes();
         SocketWrapperSpy socketWrapper = new SocketWrapperSpy(input, output);
-        Server testServer = new Server(socketWrapper, router);
+        Server testServer = new Server(router);
+        testServer.setSocketWrapper(socketWrapper);
 
         testServer.start(port);
 
@@ -139,7 +144,8 @@ public class TestFeatures {
 
         Router router = Routes.assignRoutes();
         SocketWrapperSpy socketWrapper = new SocketWrapperSpy(input, output);
-        Server testServer = new Server(socketWrapper, router);
+        Server testServer = new Server(router);
+        testServer.setSocketWrapper(socketWrapper);
 
         testServer.start(port);
 
@@ -162,7 +168,8 @@ public class TestFeatures {
 
         Router router = Routes.assignRoutes();
         SocketWrapperSpy socketWrapper = new SocketWrapperSpy(input, output);
-        Server testServer = new Server(socketWrapper, router);
+        Server testServer = new Server(router);
+        testServer.setSocketWrapper(socketWrapper);
 
         testServer.start(port);
 
@@ -185,7 +192,8 @@ public class TestFeatures {
 
         Router router = Routes.assignRoutes();
         SocketWrapperSpy socketWrapper = new SocketWrapperSpy(input, output);
-        Server testServer = new Server(socketWrapper, router);
+        Server testServer = new Server(router);
+        testServer.setSocketWrapper(socketWrapper);
 
         testServer.start(port);
 
@@ -208,7 +216,8 @@ public class TestFeatures {
 
         Router router = Routes.assignRoutes();
         SocketWrapperSpy socketWrapper = new SocketWrapperSpy(input, output);
-        Server testServer = new Server(socketWrapper, router);
+        Server testServer = new Server(router);
+        testServer.setSocketWrapper(socketWrapper);
 
         testServer.start(port);
 
@@ -231,7 +240,8 @@ public class TestFeatures {
 
         Router router = Routes.assignRoutes();
         SocketWrapperSpy socketWrapper = new SocketWrapperSpy(input, output);
-        Server testServer = new Server(socketWrapper, router);
+        Server testServer = new Server(router);
+        testServer.setSocketWrapper(socketWrapper);
 
         testServer.start(port);
 
@@ -254,7 +264,8 @@ public class TestFeatures {
 
         Router router = Routes.assignRoutes();
         SocketWrapperSpy socketWrapper = new SocketWrapperSpy(input, output);
-        Server testServer = new Server(socketWrapper, router);
+        Server testServer = new Server(router);
+        testServer.setSocketWrapper(socketWrapper);
 
         testServer.start(port);
 
@@ -279,7 +290,8 @@ public class TestFeatures {
 
         Router router = Routes.assignRoutes();
         SocketWrapperSpy socketWrapper = new SocketWrapperSpy(input, output);
-        Server testServer = new Server(socketWrapper, router);
+        Server testServer = new Server(router);
+        testServer.setSocketWrapper(socketWrapper);
 
         testServer.start(port);
 
@@ -306,7 +318,8 @@ public class TestFeatures {
 
         Router router = Routes.assignRoutes();
         SocketWrapperSpy socketWrapper = new SocketWrapperSpy(input, output);
-        Server testServer = new Server(socketWrapper, router);
+        Server testServer = new Server(router);
+        testServer.setSocketWrapper(socketWrapper);
 
         testServer.start(port);
 
@@ -333,7 +346,8 @@ public class TestFeatures {
 
         Router router = Routes.assignRoutes();
         SocketWrapperSpy socketWrapper = new SocketWrapperSpy(input, output);
-        Server testServer = new Server(socketWrapper, router);
+        Server testServer = new Server(router);
+        testServer.setSocketWrapper(socketWrapper);
 
         testServer.start(port);
 
@@ -362,7 +376,8 @@ public class TestFeatures {
 
         Router router = Routes.assignRoutes();
         SocketWrapperSpy socketWrapper = new SocketWrapperSpy(input, output);
-        Server testServer = new Server(socketWrapper, router);
+        Server testServer = new Server(router);
+        testServer.setSocketWrapper(socketWrapper);
 
         testServer.start(port);
 
@@ -389,7 +404,8 @@ public class TestFeatures {
 
         Router router = Routes.assignRoutes();
         SocketWrapperSpy socketWrapper = new SocketWrapperSpy(input, output);
-        Server testServer = new Server(socketWrapper, router);
+        Server testServer = new Server(router);
+        testServer.setSocketWrapper(socketWrapper);
 
         testServer.start(port);
 
@@ -416,7 +432,8 @@ public class TestFeatures {
 
         Router router = Routes.assignRoutes();
         SocketWrapperSpy socketWrapper = new SocketWrapperSpy(input, output);
-        Server testServer = new Server(socketWrapper, router);
+        Server testServer = new Server(router);
+        testServer.setSocketWrapper(socketWrapper);
 
         testServer.start(port);
 
@@ -442,7 +459,8 @@ public class TestFeatures {
 
         Router router = Routes.assignRoutes();
         SocketWrapperSpy socketWrapper = new SocketWrapperSpy(input, output);
-        Server testServer = new Server(socketWrapper, router);
+        Server testServer = new Server(router);
+        testServer.setSocketWrapper(socketWrapper);
 
         testServer.start(port);
 
@@ -468,7 +486,8 @@ public class TestFeatures {
 
         Router router = Routes.assignRoutes();
         SocketWrapperSpy socketWrapper = new SocketWrapperSpy(input, output);
-        Server testServer = new Server(socketWrapper, router);
+        Server testServer = new Server(router);
+        testServer.setSocketWrapper(socketWrapper);
 
         testServer.start(port);
 

--- a/src/test/java/TestServerSocket.java
+++ b/src/test/java/TestServerSocket.java
@@ -21,7 +21,8 @@ public class TestServerSocket {
 
         Router router = Routes.assignRoutes();
         SocketWrapperSpy socketWrapper = new SocketWrapperSpy(input, output);
-        Server testServer = new Server(socketWrapper, router);
+        Server testServer = new Server(router);
+        testServer.setSocketWrapper(socketWrapper);
 
         testServer.start(port);
 
@@ -40,7 +41,8 @@ public class TestServerSocket {
 
         Router router = Routes.assignRoutes();
         SocketWrapperSpy socketWrapper = new SocketWrapperSpy(input, output);
-        Server testServer = new Server(socketWrapper, router);
+        Server testServer = new Server(router);
+        testServer.setSocketWrapper(socketWrapper);
 
         testServer.start(port);
 
@@ -60,7 +62,8 @@ public class TestServerSocket {
 
         Router router = Routes.assignRoutes();
         SocketWrapperSpy socketWrapper = new SocketWrapperSpy(input, output);
-        Server testServer = new Server(socketWrapper, router);
+        Server testServer = new Server(router);
+        testServer.setSocketWrapper(socketWrapper);
 
         testServer.start(port);
 
@@ -80,7 +83,8 @@ public class TestServerSocket {
 
         Router router = Routes.assignRoutes();
         SocketWrapperSpy socketWrapper = new SocketWrapperSpy(input, output);
-        Server testServer = new Server(socketWrapper, router);
+        Server testServer = new Server(router);
+        testServer.setSocketWrapper(socketWrapper);
 
         testServer.start(port);
 
@@ -100,7 +104,8 @@ public class TestServerSocket {
 
         Router router = Routes.assignRoutes();
         SocketWrapperSpy socketWrapper = new SocketWrapperSpy(input, output);
-        Server testServer = new Server(socketWrapper, router);
+        Server testServer = new Server(router);
+        testServer.setSocketWrapper(socketWrapper);
 
         testServer.start(port);
 
@@ -122,7 +127,8 @@ public class TestServerSocket {
 
         Router router = Routes.assignRoutes();
         SocketWrapperSpy socketWrapper = new SocketWrapperSpy(input, output);
-        Server testServer = new Server(socketWrapper, router);
+        Server testServer = new Server(router);
+        testServer.setSocketWrapper(socketWrapper);
 
         testServer.start(port);
 


### PR DESCRIPTION
- removed SocketWrapper as a parameter of Server - it now defaults to ServerSocketWrapper with a setSocketWrapper method if change is needed for testing or fun